### PR TITLE
Fixed cookiecutter exception on incorrect Jinja syntax

### DIFF
--- a/extension-template/{{ cookiecutter.extension_name }}/create_package.sh
+++ b/extension-template/{{ cookiecutter.extension_name }}/create_package.sh
@@ -34,7 +34,7 @@ function usage {
 }
 
 # If no arguments provided
-if [[ ${#} -eq 0 ]]; then
+if [[ $# -eq 0 ]]; then
    usage
 fi
 


### PR DESCRIPTION
Current `create_package.sh` has a syntax that is causing problems with Cookiecutter execution.

Fixed check for empty list of parameters 